### PR TITLE
I want to do arbitrary processing after rotate

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -65,15 +65,14 @@
   version = "v1.0"
 
 [[projects]]
-  digest = "1:8f5579a88f14ca4029f38f7491f12f578e38d942d9343e63aaa68f14c31df053"
+  digest = "1:7a203f9ac5c9e1284cdf0d818bd22587a87484934546eacc6a86e3278800b60a"
   name = "github.com/lestrrat-go/file-rotatelogs"
   packages = [
     ".",
     "internal/option",
   ]
   pruneopts = "UT"
-  revision = "3b4f34a036f374c18d604e1b8006d9fbb9593c06"
-  version = "v2.2.0"
+  revision = "00616292e7713245e4988c7d3a7aae395665e49f"
 
 [[projects]]
   digest = "1:ae9d3d846ce86fcd7e0f691d5282743d0de3ce6fc4e21dbb28067f1f1f53cef9"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -27,7 +27,7 @@
 
 [[constraint]]
   name = "github.com/lestrrat-go/file-rotatelogs"
-  version = "2.2.0"
+  revision = "00616292e7713245e4988c7d3a7aae395665e49f"
 
 [[constraint]]
   name = "github.com/lestrrat-go/server-starter"

--- a/README.md
+++ b/README.md
@@ -85,6 +85,10 @@ format = "ltsv"
 rotateEnable = true
 rotationTime = "daily"
 rotationCount = 7
+# You can execute arbitrary commands after rotate
+# $1 = prev filename
+# $2 = current filename
+rotationHook = "/path/to/after_rotate.sh"
 
 [dumpLog]
 dir = "/var/log/dump"

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -189,14 +189,14 @@ func newLogWriter(logType string) io.Writer {
 		switch rotationTime {
 		case "hourly":
 			logSuffix = ".%Y%m%d%H"
-			options = append(options, rotatelogs.WithLinkName(path))
 		case "daily":
 			logSuffix = ".%Y%m%d"
-			options = append(options, rotatelogs.WithLinkName(path))
 		case "monthly":
 			logSuffix = ".%Y%m"
-			options = append(options, rotatelogs.WithLinkName(path))
+		default:
+			log.Fatal("Log setting error, please specify one of the periods [hourly, daily, monthly]")
 		}
+		options = append(options, rotatelogs.WithLinkName(path))
 		w, err = rotatelogs.New(
 			path+logSuffix,
 			options...,

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -187,11 +187,15 @@ func newLogWriter(logType string) io.Writer {
 	var w io.Writer
 	if rotateEnable {
 		switch rotationTime {
-		case "hourly", "daily", "monthly":
+		case "hourly":
 			logSuffix = ".%Y%m%d%H"
 			options = append(options, rotatelogs.WithLinkName(path))
-		default:
-			log.Fatal("Log setting error, please specify one of the periods [hourly, daily, monthly]")
+		case "daily":
+			logSuffix = ".%Y%m%d"
+			options = append(options, rotatelogs.WithLinkName(path))
+		case "monthly":
+			logSuffix = ".%Y%m"
+			options = append(options, rotatelogs.WithLinkName(path))
 		}
 		w, err = rotatelogs.New(
 			path+logSuffix,

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -181,15 +181,11 @@ func newLogWriter(logType string) io.Writer {
 	var w io.Writer
 	if rotateEnable {
 		switch rotationTime {
-		case "hourly":
+		case "hourly", "daily", "monthly":
 			logSuffix = ".%Y%m%d%H"
 			options = append(options, rotatelogs.WithLinkName(path))
-		case "daily":
-			logSuffix = ".%Y%m%d"
-			options = append(options, rotatelogs.WithLinkName(path))
-		case "monthly":
-			logSuffix = ".%Y%m"
-			options = append(options, rotatelogs.WithLinkName(path))
+		default:
+			log.Fatal("Log setting error, please specify one of the periods [hourly, daily, monthly]")
 		}
 		w, err = rotatelogs.New(
 			path+logSuffix,

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -8,6 +8,8 @@ import (
 	"os/exec"
 	"path/filepath"
 
+	"time"
+
 	"github.com/hnakamur/zap-ltsv"
 	rotatelogs "github.com/lestrrat-go/file-rotatelogs"
 	"github.com/spf13/viper"
@@ -183,20 +185,21 @@ func newLogWriter(logType string) io.Writer {
 	if rotationHook != "" {
 		options = append(options, rotatelogs.WithHandler(NewRotateHandler(rotationHook)))
 	}
-
 	var w io.Writer
+	var t time.Duration
 	if rotateEnable {
 		switch rotationTime {
 		case "hourly":
 			logSuffix = ".%Y%m%d%H"
+			t = 1 * time.Hour
 		case "daily":
 			logSuffix = ".%Y%m%d"
-		case "monthly":
-			logSuffix = ".%Y%m"
+			t = 24 * time.Hour
 		default:
-			log.Fatal("Log setting error, please specify one of the periods [hourly, daily, monthly]")
+			log.Fatal("Log setting error, please specify one of the periods [hourly, daily]")
 		}
 		options = append(options, rotatelogs.WithLinkName(path))
+		options = append(options, rotatelogs.WithRotationTime(t))
 		w, err = rotatelogs.New(
 			path+logSuffix,
 			options...,

--- a/vendor/github.com/lestrrat-go/file-rotatelogs/.travis.yml
+++ b/vendor/github.com/lestrrat-go/file-rotatelogs/.travis.yml
@@ -1,5 +1,5 @@
 language: go
 sudo: false
 go:
-  - 1.7
+  - "1.10"
   - tip

--- a/vendor/github.com/lestrrat-go/file-rotatelogs/README.md
+++ b/vendor/github.com/lestrrat-go/file-rotatelogs/README.md
@@ -164,6 +164,25 @@ Note: MaxAge should be disabled by specifing `WithMaxAge(-1)` explicitly.
   )
 ```
 
+## Handler (default: nil)
+
+Sets the event handler to receive event notifications from the RotateLogs
+object. Currently only supported event type is FiledRotated
+
+```go
+  rotatelogs.New(
+    "/var/log/myapp/log.%Y%m%d",
+    rotatelogs.Handler(rotatelogs.HandlerFunc(func(e Event) {
+      if e.Type() != rotatelogs.FileRotatedEventType {
+        return
+      }
+
+      // Do what you want with the data. This is just an idea:
+      storeLogFileToRemoteStorage(e.(*FileRotatedEvent).PreviousFile())
+    })),
+  )
+```
+
 # Rotating files forcefully
 
 If you want to rotate files forcefully before the actual rotation time has reached,

--- a/vendor/github.com/lestrrat-go/file-rotatelogs/event.go
+++ b/vendor/github.com/lestrrat-go/file-rotatelogs/event.go
@@ -1,0 +1,17 @@
+package rotatelogs
+
+func (h HandlerFunc) Handle(e Event) {
+	h(e)
+}
+
+func (e *FileRotatedEvent) Type() EventType {
+	return FileRotatedEventType
+}
+
+func (e *FileRotatedEvent) PreviousFile() string {
+	return e.prev
+}
+
+func (e *FileRotatedEvent) CurrentFile() string {
+	return e.current
+}

--- a/vendor/github.com/lestrrat-go/file-rotatelogs/interface.go
+++ b/vendor/github.com/lestrrat-go/file-rotatelogs/interface.go
@@ -8,6 +8,28 @@ import (
 	strftime "github.com/lestrrat-go/strftime"
 )
 
+type Handler interface {
+	Handle(Event)
+}
+
+type HandlerFunc func(Event)
+
+type Event interface {
+	Type() EventType
+}
+
+type EventType int
+
+const (
+	InvalidEventType EventType = iota
+	FileRotatedEventType
+)
+
+type FileRotatedEvent struct {
+	prev    string // previous filename
+	current string // current, new filename
+}
+
 // RotateLogs represents a log file that gets
 // automatically rotated as you write to it.
 type RotateLogs struct {
@@ -18,6 +40,7 @@ type RotateLogs struct {
 	linkName      string
 	maxAge        time.Duration
 	mutex         sync.RWMutex
+	eventHandler  Handler
 	outFh         *os.File
 	pattern       *strftime.Strftime
 	rotationTime  time.Duration
@@ -43,5 +66,5 @@ var Local = clockFn(time.Now)
 // the RotateLogs constructor
 type Option interface {
 	Name() string
-	Value() interface {}
+	Value() interface{}
 }

--- a/vendor/github.com/lestrrat-go/file-rotatelogs/options.go
+++ b/vendor/github.com/lestrrat-go/file-rotatelogs/options.go
@@ -8,6 +8,7 @@ import (
 
 const (
 	optkeyClock         = "clock"
+	optkeyHandler       = "handler"
 	optkeyLinkName      = "link-name"
 	optkeyMaxAge        = "max-age"
 	optkeyRotationTime  = "rotation-time"
@@ -63,4 +64,11 @@ func WithRotationTime(d time.Duration) Option {
 // purged from the file system.
 func WithRotationCount(n uint) Option {
 	return option.New(optkeyRotationCount, n)
+}
+
+// WithHandler creates a new Option that specifies the
+// Handler object that gets invoked when an event occurs.
+// Currently `FileRotated` event is supported
+func WithHandler(h Handler) Option {
+	return option.New(optkeyHandler, h)
 }


### PR DESCRIPTION
Implementing it because there are various use cases, such as compressing files after log rotation.
```toml
rotationHook = "/path/to/after_rotate.sh"
```

will be executed like this.
```bash
$ /path/to/after_rotate.sh prevfile.log currentfile.log
```