### PR TITLE
Use LABEL instead of MAINTAINER (for deprecation)

### DIFF
--- a/dockerfiles/Dockerfile.centos6
+++ b/dockerfiles/Dockerfile.centos6
@@ -1,5 +1,5 @@
 FROM centos:6
-MAINTAINER k1LoW <k1lowxb@gmail.com>
+LABEL maintainer="k1LoW <k1lowxb@gmail.com>"
 
 ARG GO_VERSION
 ARG LIBPCAP_VERSION

--- a/dockerfiles/Dockerfile.centos7
+++ b/dockerfiles/Dockerfile.centos7
@@ -1,5 +1,5 @@
 FROM centos:7
-MAINTAINER k1LoW <k1lowxb@gmail.com>
+LABEL maintainer="k1LoW <k1lowxb@gmail.com>"
 
 ARG GO_VERSION
 ARG LIBPCAP_VERSION

--- a/dockerfiles/Dockerfile.ubuntu16
+++ b/dockerfiles/Dockerfile.ubuntu16
@@ -1,5 +1,5 @@
 FROM ubuntu:xenial
-MAINTAINER k1LoW <k1lowxb@gmail.com>
+LABEL maintainer="k1LoW <k1lowxb@gmail.com>"
 
 ARG GO_VERSION
 ARG LIBPCAP_VERSION


### PR DESCRIPTION
MAINTAINER instruction is deprecated as of Docker 1.13.
Instead, you'd use LABEL instruction, which enable setting metadata.

See also: https://docs.docker.com/engine/reference/builder/#maintainer-deprecated