### PR TITLE
Fix busy loop

### DIFF
--- a/reader/reader.go
+++ b/reader/reader.go
@@ -218,7 +218,6 @@ func (r *PacketReader) ReadAndDump(host string, port uint16) error {
 			values = append(values, connMetadata.DumpValues...)
 
 			r.dumper.Log(values)
-		default:
 		}
 	}
 }


### PR DESCRIPTION
## before

```console
$ go tool pprof -seconds 5 http://localhost:6060/debug/pprof/profile
Fetching profile over HTTP from http://localhost:6060/debug/pprof/profile?seconds=5
Please wait... (5s)
Saved profile in /Users/k1low/pprof/pprof.samples.cpu.007.pb.gz
Type: cpu
Time: Sep 29, 2018 at 12:54am (JST)
Duration: 5.14s, Total samples = 4.40s (85.59%)
Entering interactive mode (type "help" for commands, "o" for options)
(pprof) top
Showing nodes accounting for 3870ms, 87.95% of 4400ms total
Dropped 10 nodes (cum <= 22ms)
Showing top 10 nodes out of 21
      flat  flat%   sum%        cum   cum%
    1440ms 32.73% 32.73%     3550ms 80.68%  runtime.selectgo
     480ms 10.91% 43.64%      480ms 10.91%  runtime.unlock
     450ms 10.23% 53.86%      450ms 10.23%  runtime.lock
     360ms  8.18% 62.05%      360ms  8.18%  runtime.cputicks
     240ms  5.45% 67.50%      720ms 16.36%  runtime.selunlock
     240ms  5.45% 72.95%      240ms  5.45%  sync.(*Mutex).Unlock
     220ms  5.00% 77.95%      220ms  5.00%  sync.(*Mutex).Lock
     160ms  3.64% 81.59%      160ms  3.64%  runtime.(*hchan).sortkey (inline)
     140ms  3.18% 84.77%     4350ms 98.86%  github.com/k1LoW/tcpdp/reader.(*PacketReader).ReadAndDump
     140ms  3.18% 87.95%      140ms  3.18%  runtime.duffzero
```

<img width="1058" alt="2018-09-29 2 28 24" src="https://user-images.githubusercontent.com/57114/46223840-72e2b580-c38f-11e8-9e0b-0867408160a9.png">


## after

```console
$ go tool pprof -seconds 5 http://localhost:6060/debug/pprof/profile
Fetching profile over HTTP from http://localhost:6060/debug/pprof/profile?seconds=5
Please wait... (5s)
Saved profile in /Users/k1low/pprof/pprof.samples.cpu.013.pb.gz
Type: cpu
Time: Sep 29, 2018 at 2:27am (JST)
Duration: 5s, Total samples = 20ms (  0.4%)
Entering interactive mode (type "help" for commands, "o" for options)
(pprof) top
Showing nodes accounting for 20ms, 100% of 20ms total
      flat  flat%   sum%        cum   cum%
      20ms   100%   100%       20ms   100%  github.com/k1LoW/tcpdp/vendor/github.com/google/gopacket/pcap.(*Handle).getNextBufPtrLocked.func1
         0     0%   100%       20ms   100%  github.com/k1LoW/tcpdp/vendor/github.com/google/gopacket.(*PacketSource).NextPacket
         0     0%   100%       20ms   100%  github.com/k1LoW/tcpdp/vendor/github.com/google/gopacket.(*PacketSource).packetsToChannel
         0     0%   100%       20ms   100%  github.com/k1LoW/tcpdp/vendor/github.com/google/gopacket/pcap.(*Handle).ReadPacketData
         0     0%   100%       20ms   100%  github.com/k1LoW/tcpdp/vendor/github.com/google/gopacket/pcap.(*Handle).getNextBufPtrLocked
```

<img width="1079" alt="2018-09-29 2 28 33" src="https://user-images.githubusercontent.com/57114/46223846-78d89680-c38f-11e8-85f9-8024a202a120.png">
