### PR TITLE
Check clientSSL when parsing HandshakeResponse and write warning to dump.log

### DIFF
--- a/dumper/mysql/mysql.go
+++ b/dumper/mysql/mysql.go
@@ -65,7 +65,7 @@ func (m *Dumper) Dump(in []byte, direction dumper.Direction, connMetadata *dumpe
 
 // Read return byte to analyzed string
 func (m *Dumper) Read(in []byte, direction dumper.Direction, connMetadata *dumper.ConnMetadata) []dumper.DumpValue {
-	values := m.readClientCapabilities(in, direction, connMetadata)
+	values := m.readHandshakeResponse(in, direction, connMetadata)
 	connMetadata.DumpValues = append(connMetadata.DumpValues, values...)
 	cSet := connMetadata.Internal.(connMetadataInternal).charSet
 
@@ -256,7 +256,7 @@ func (m *Dumper) NewConnMetadata() *dumper.ConnMetadata {
 	}
 }
 
-func (m *Dumper) readClientCapabilities(in []byte, direction dumper.Direction, connMetadata *dumper.ConnMetadata) []dumper.DumpValue {
+func (m *Dumper) readHandshakeResponse(in []byte, direction dumper.Direction, connMetadata *dumper.ConnMetadata) []dumper.DumpValue {
 	values := []dumper.DumpValue{}
 	if direction == dumper.RemoteToClient || direction == dumper.DstToSrc {
 		return values
@@ -267,7 +267,7 @@ func (m *Dumper) readClientCapabilities(in []byte, direction dumper.Direction, c
 
 	clientCapabilities := binary.LittleEndian.Uint32(in[4:8])
 
-	// parse Protocol::HandshakeResponse41 to get username, database
+	// parse Protocol::HandshakeResponse41
 	if clientCapabilities&uint32(clientProtocol41) > 0 && bytes.Compare(in[13:36], []byte{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}) == 0 {
 		internal := connMetadata.Internal.(connMetadataInternal)
 

--- a/dumper/mysql/mysql_test.go
+++ b/dumper/mysql/mysql_test.go
@@ -402,6 +402,31 @@ var mysqlReadTests = []struct {
 		},
 		"\"stmt_execute_values\":[1,23.4,0]",
 	},
+	{
+		"tcpdp mysql dumper not support SSL connection (https://dev.mysql.com/doc/internals/en/ssl.html)",
+		[]byte{
+			0x20, 0x00, 0x00, 0x01, 0x05, 0xae, 0x03, 0x00, 0x00, 0x00, 0x00, 0x01, 0x08, 0x00, 0x00, 0x00,
+			0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+			0x00, 0x00, 0x00, 0x00,
+		},
+		dumper.ClientToRemote,
+		dumper.ConnMetadata{
+			DumpValues: []dumper.DumpValue{},
+			Internal: connMetadataInternal{
+				stmtNumParams:      stmtNumParams{},
+				clientCapabilities: clientCapabilities{},
+				charSet:            charSetUnknown,
+			},
+		},
+		[]dumper.DumpValue{
+			dumper.DumpValue{
+				Key:   "character_set",
+				Value: "latin1",
+			},
+		},
+		[]dumper.DumpValue{},
+		"\"error\":\"client is trying to connect using SSL. tcpdp mysql dumper not support SSL connection\"",
+	},
 }
 
 func TestMysqlReadUsernameAndDatabaseHandshakeResponse41(t *testing.T) {

--- a/dumper/mysql/mysql_test.go
+++ b/dumper/mysql/mysql_test.go
@@ -414,7 +414,7 @@ func TestMysqlReadUsernameAndDatabaseHandshakeResponse41(t *testing.T) {
 		direction := tt.direction
 		connMetadata := &tt.connMetadata
 
-		actual := d.readClientCapabilities(in, direction, connMetadata)
+		actual := d.readHandshakeResponse(in, direction, connMetadata)
 		expected := tt.expected
 
 		if len(actual) != len(expected) {

--- a/go.mod
+++ b/go.mod
@@ -37,6 +37,7 @@ require (
 	github.com/mattn/go-isatty v0.0.4 // indirect
 	github.com/mitchellh/colorstring v0.0.0-20150917214807-8631ce90f286 // indirect
 	github.com/mitchellh/go-homedir v1.0.0 // indirect
+	github.com/pkg/errors v0.8.0
 	github.com/rainycape/unidecode v0.0.0-20150907023854-cb7f23ec59be // indirect
 	github.com/rs/xid v1.2.1
 	github.com/ryanuber/go-glob v0.0.0-20170128012129-256dc444b735 // indirect

--- a/go.mod
+++ b/go.mod
@@ -53,5 +53,5 @@ require (
 	golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be // indirect
 	golang.org/x/text v0.3.0
 	golang.org/x/time v0.0.0-20180412165947-fbb02b2291d2 // indirect
-	golang.org/x/tools v0.0.0-20181016205153-5ef16f43e633 // indirect
+	golang.org/x/tools v0.0.0-20181017214349-06f26fdaaa28 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -201,6 +201,8 @@ golang.org/x/tools v0.0.0-20181013182035-5e66757b835f h1:rUshVq0fjlLKvS31sAnzn67
 golang.org/x/tools v0.0.0-20181013182035-5e66757b835f/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20181016205153-5ef16f43e633 h1:qw2Vc7kL8YR/N2OwEgaPAolq/EnxaQSB2Ei1YyReZaM=
 golang.org/x/tools v0.0.0-20181016205153-5ef16f43e633/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
+golang.org/x/tools v0.0.0-20181017214349-06f26fdaaa28 h1:vnbqcYKfOxPnXXUlBo7t+R4pVIh0wInyOSNxih1S9Dc=
+golang.org/x/tools v0.0.0-20181017214349-06f26fdaaa28/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.2.1 h1:mUhvW9EsL+naU5Q3cakzfE91YhliOondGd6ZrsDBHQE=
 gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=


### PR DESCRIPTION
Because, tcpdp mysql dumper not support SSL connection, now.