### PR TITLE
fix a typo in doc string

### DIFF
--- a/cmd/probe.go
+++ b/cmd/probe.go
@@ -47,7 +47,7 @@ const snaplenDefault = 0xFFFF
 var probeCmd = &cobra.Command{
 	Use:   "probe",
 	Short: "Probe mode",
-	Long:  "`tcp prove` dump packets like tcpdump.",
+	Long:  "`tcp probe` dump packets like tcpdump.",
 	Run: func(cmd *cobra.Command, args []string) {
 		err := viper.ReadInConfig()
 		if err != nil {


### PR DESCRIPTION
I believe `tcpdp prove` must be `tcpdp probe`.